### PR TITLE
Add aifuel: AI usage monitor for waybar

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ wf-dock (part of [wf-shell](https://github.com/WayfireWM/wf-shell)) - Very simpl
 * wf-panel (part of [wf-shell](https://github.com/WayfireWM/wf-shell)) - Panel with support for application launchers
 * [YaGoStatus](https://github.com/denysvitali/yagostatus) - Yet Another i3status replacement
 * [yambar](https://gitlab.com/dnkl/yambar) - Modular status panel for X11 and Wayland, inspired by polybar
+* [aifuel](https://github.com/robertogogoni/aifuel) - Real-time AI provider usage monitor for waybar with Chrome extension, bubbletea TUI dashboard, and Catppuccin theme
 
 ## Tools
 


### PR DESCRIPTION
Adding [aifuel](https://github.com/robertogogoni/aifuel) to the Status Bars section.

aifuel is a Go CLI that monitors AI provider usage (Claude, Codex, Gemini, Copilot) and renders it as a color-coded fuel gauge in waybar. It includes a Chrome extension with popup UI, a bubbletea real-time TUI dashboard, Admin API cost reports, and Catppuccin Mocha theming throughout.